### PR TITLE
fix: remove required toolchain java 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,12 +110,6 @@ android {
   }
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
-}
-
 repositories {
   mavenCentral()
   google()


### PR DESCRIPTION
### Hello
After working on this issue [https://github.com/AndrewDongminYoo/react-native-step-counter/issues/33](issue-33)
I found that this is build.grandle only requires Java 8 to run.
But in Java 8 jlink is not available. So I remove it, then I can build react-native app
Please review my pull request.