### PR TITLE
fixed sensorManager lateinit definition

### DIFF
--- a/android/src/main/java/com/stepcounter/StepCounterModule.kt
+++ b/android/src/main/java/com/stepcounter/StepCounterModule.kt
@@ -35,7 +35,7 @@ class StepCounterModule internal constructor(context: ReactApplicationContext) :
     }
 
     private val appContext: ReactApplicationContext = context
-    private val lateinit sensorManager: SensorManager
+    private lateinit var sensorManager: SensorManager
     private val stepsOK: Boolean
         get() = checkSelfPermission(appContext, STEP_COUNTER) == PERMISSION_GRANTED
     private val accelOK: Boolean


### PR DESCRIPTION
# Fix: Incorrect lateinit Property Declaration in StepCounterModule

## Issue
The StepCounterModule.kt file contained an incorrect Kotlin property declaration that was causing compilation errors. The `lateinit` modifier was incorrectly used with a `val` property and placed in the wrong position in the declaration:

```kotlin
private val lateinit sensorManager: SensorManager
```

This syntax is invalid in Kotlin and causes the following compilation error:
```
Property getter or setter expected
```

Additionally, this led to several "Unresolved reference: sensorManager" errors throughout the file as the property wasn't properly initialized.

## Fix
Modified the property declaration to use the correct Kotlin syntax for lateinit properties:

```kotlin
private lateinit var sensorManager: SensorManager
```

This change:
- Uses the `lateinit` modifier before the `var` keyword (lateinit can only be used with `var`, not `val`)
- Follows Kotlin's proper property declaration syntax
- Maintains the same functionality while fixing the compilation errors
- Keeps the property non-null while allowing initialization in the `init` block

## Testing
- Verified that the code compiles successfully
- Confirmed that the step counter functionality works as expected
- No changes to the actual behavior of the module

This fix allows the module to be used in React Native projects without compilation errors while maintaining all existing functionality.