### PR TITLE
ci: skip workflow runs on bot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ permissions: read-all
 
 jobs:
   lint:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -31,6 +32,7 @@ jobs:
         run: yarn typecheck
 
   build-library:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -44,6 +46,7 @@ jobs:
         run: yarn prepare
 
   build-android:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -79,6 +82,7 @@ jobs:
         run: yarn example build:android
 
   build-ios:
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]", "snyk-bot", "allcontributors[bot]"]'), github.actor) }}
     runs-on: macos-latest
 
     env:


### PR DESCRIPTION
Adds an `if` condition to every job so that dependency-bot PRs (dependabot, renovate, etc.) do not trigger Actions runs, reducing unnecessary minutes usage.