### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,7 +52,7 @@ Please provide a concise description of what this PR does and why.
      startStepCounterUpdate,
      stopStepCounterUpdate,
      type ParsedStepCountData,
-   } from '@dongminyu/react-native-step-counter';
+   } from 'react-native-step-counter-newarch';
    // …
    ```
 

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -8,11 +8,11 @@
 ## Tech Stack
 
 - TypeScript for JS bridge/public API (`src/`)
-- React Native 0.83 / React 19
+- React Native 0.85 / React 19
 - Native Android module under `android/src/main/`
 - Native iOS module under `ios/` (`StepCounter.mm`, `SOMotionDetecter.*`)
 - Build packaging via `react-native-builder-bob` -> output in `lib/`
-- Tests via Jest (`react-native` preset)
+- Tests via Jest (`@react-native/jest-preset` preset)
 - Quality/linting/formatting/security checks via Trunk
 
 ## High-Level Structure

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-- Name: `@dongminyu/react-native-step-counter`
+- Name: `react-native-step-counter-newarch`
 - Purpose: React Native native module for step counting on Android/iOS, exposing a TypeScript API. Android uses StepCounter sensor with accelerometer fallback, iOS uses Core Motion (`CMPedometer`).
 - Architecture: React Native New Architecture (TurboModule/Fabric) is required from `v0.3.0`; compatibility considerations for native platforms are documented in `README.md`.
 - Repo shape: Yarn workspace monorepo with library at root and integration example app in `example/`.

--- a/.serena/memories/style_and_conventions.md
+++ b/.serena/memories/style_and_conventions.md
@@ -24,7 +24,7 @@
 
 ## Testing Conventions
 
-- Jest with `react-native` preset (`jest.config.js`)
+- Jest with `@react-native/jest-preset` preset (`jest.config.js`)
 - Test file names: `*.test.ts` or `*.test.tsx`
 - Prefer colocated tests or `src/__tests__/`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
 
 ## Testing Guidelines
 
-- Jest is configured via `jest.config.js` (`react-native` preset) and `jest.setup.ts`.
+- Jest is configured via `jest.config.js` (`@react-native/jest-preset` preset) and `jest.setup.ts`.
 - Add tests as `*.test.ts` / `*.test.tsx` (prefer colocated tests or `src/__tests__/`).
 - Run unit tests with `yarn jest --coverage`.
 - For native changes, validate behavior in `example/` on affected platforms (Android/iOS).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.5.0](https://github.com/AndrewDongminYoo/react-native-step-counter/compare/v0.4.0...v0.5.0) (2026-07-12)
+
+### ⚠ BREAKING CHANGES
+
+- 📦 **Package renamed to `react-native-step-counter-newarch`** (previously `@dongminyu/react-native-step-counter`). Update your dependency and every import path. The unscoped `react-native-step-counter` name is blocked by npm's name-similarity check (it normalizes to the same string as the 2016 `react-native-stepcounter` fork of `react-native-pedometer`), so the New Architecture identity is signaled with a `-newarch` suffix. The GitHub repository is unchanged. ([6f9caab](https://github.com/AndrewDongminYoo/react-native-step-counter/commit/6f9caab))
+
+### Bug Fixes
+
+- 🐛 **JSDoc type parsing**: Corrected the `@returns` inline object type in the doc comments (`;` → `,`) so `jsdoc` can parse the type expression and generate the API documentation. ([a415320](https://github.com/AndrewDongminYoo/react-native-step-counter/commit/a415320))
+
+### Documentation
+
+- 📝 **Knowledge layer reconciled**: Aligned `CLAUDE.md`, `AGENTS.md`, and the Serena memory files with the current code — public API surface, Jest preset, Node channel, React Native peer range, and the timestamp flow. ([c53b351](https://github.com/AndrewDongminYoo/react-native-step-counter/commit/c53b351))
+- 📝 Regenerated the JSDoc API documentation. ([e6b0054](https://github.com/AndrewDongminYoo/react-native-step-counter/commit/e6b0054))
+
+### Chore Changes
+
+- 🔨 Quoted the `NODE_BINARY` command in the iOS example build for consistency. ([b13954c](https://github.com/AndrewDongminYoo/react-native-step-counter/commit/b13954c))
+- 👷 Added native Android and iOS example build workflows. ([10d9750](https://github.com/AndrewDongminYoo/react-native-step-counter/commit/10d9750))
+
 ## [0.4.0](https://github.com/AndrewDongminYoo/react-native-step-counter/compare/v0.3.1...v0.4.0) (2026-05-24)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - 🔨 Quoted the `NODE_BINARY` command in the iOS example build for consistency. ([b13954c](https://github.com/AndrewDongminYoo/react-native-step-counter/commit/b13954c))
 - 👷 Added native Android and iOS example build workflows. ([10d9750](https://github.com/AndrewDongminYoo/react-native-step-counter/commit/10d9750))
+- 🔒 Resolved reported OSV advisories in transitive/dev dependencies via Yarn `resolutions` (`ws`, `undici`, `js-yaml`, `joi`, `launch-editor`, `shell-quote`, `tar`, `@babel/core`). The pin-blocked `concurrent-ruby` advisories — example iOS build tooling, not shipped in the package — are recorded in `example/osv-scanner.toml`.
 
 ## [0.4.0](https://github.com/AndrewDongminYoo/react-native-step-counter/compare/v0.3.1...v0.4.0) (2026-05-24)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`@dongminyu/react-native-step-counter` is a React Native **TurboModule library** that tracks step counts using native device sensors. It uses the **New Architecture** (Fabric/TurboModules) and is built with `react-native-builder-bob`.
+`react-native-step-counter-newarch` is a React Native **TurboModule library** that tracks step counts using native device sensors. It uses the **New Architecture** (Fabric/TurboModules) and is built with `react-native-builder-bob`.
 
 - iOS: Uses `CMPedometer` (CoreMotion) and `SOMotionDetecter`
 - Android: Uses the hardware step counter sensor (API 19+) with accelerometer fallback
@@ -124,6 +124,6 @@ The `jest-config` package is used in `jest.config.js` for default `moduleFileExt
 
 ## Editing Native Code
 
-- **Xcode**: Open `example/ios/StepCounterExample.xcworkspace`. Library files are under `Pods > Development Pods > @dongminyu/react-native-step-counter`.
-- **Android Studio**: Open `example/android`. Library files appear under `dongminyu-react-native-step-counter`.
+- **Xcode**: Open `example/ios/StepCounterExample.xcworkspace`. Library files are under `Pods > Development Pods > react-native-step-counter-newarch`.
+- **Android Studio**: Open `example/android`. Library files appear under `react-native-step-counter-newarch`.
 - After any native change, rebuild the example app (`yarn example android` or `yarn example ios`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ yarn example build:ios      # Build iOS in Debug mode
 ### Clean Build Artifacts
 
 ```sh
-yarn clean                  # Remove android/build, example/android/build, example/android/app/build, example/ios/build, lib/
+yarn clean                  # Remove android/build, example/android/build, example/android/app/build, example/ios/build, example/ios/Pods, lib/
 ```
 
 ### iOS Setup (after native changes)
@@ -72,9 +72,9 @@ Config in `.release-it.json`. Uses `@release-it/conventional-changelog` with con
 - **`src/index.tsx`** — Public API. Wraps the native module with a `NativeEventEmitter`, exposes:
   - `isStepCountingSupported()` → Promise with `{ supported, granted }`
   - `startStepCounterUpdate(start, callback)` → returns `EventSubscription`
-  - `stopStepCounterUpdate()` → removes all listeners and stops native updates
+  - `stopStepCounterUpdate()` → removes only the subscription created by the most recent `startStepCounterUpdate` (tracked as `_activeSubscription`) and stops native updates; external listeners are left intact
   - `parseStepData(data)` → transforms raw `StepCountData` into human-readable `ParsedStepCountData`
-  - `isSensorWorking` — boolean based on active listener count
+  - `createStepCountFilter(options?)` → returns a stateful filter that drops false-positive bursts (any cadence faster than `minimumStepIntervalMs`, default 250) and rebases later cumulative values so ignored steps do not reappear
 
 ### Native Layer
 
@@ -103,23 +103,23 @@ Config in `.release-it.json`. Uses `@release-it/conventional-changelog` with con
 
 ## Testing
 
-Jest is configured in `jest.config.js` (preset: `react-native`). `jest.setup.ts` mocks `TurboModuleRegistry.getEnforcing` globally, returning stubs for all native methods. Currently no test files exist; tests should be placed under `src/__tests__/`.
+Jest is configured in `jest.config.js` (preset: `@react-native/jest-preset`). `jest.setup.ts` mocks `TurboModuleRegistry.getEnforcing` globally, returning stubs for all native methods. Tests live under `src/__tests__/` (e.g. `index.test.ts`).
 
 The `jest-config` package is used in `jest.config.js` for default `moduleFileExtensions`. `modulePathIgnorePatterns` excludes `example/node_modules` and `lib/`.
 
 ## Compatibility
 
 - **v0.3.0+**: New Architecture (TurboModule/Fabric) is **required**. The library no longer supports the legacy bridge architecture.
-- **Not supported**: Expo Go, Expo managed workflow, React Native < 0.68.
+- **Not supported**: Expo Go, Expo managed workflow, React Native < 0.71 (the `react-native` peer dependency requires `>=0.71.0`).
 - For legacy architecture support, use a version prior to v0.3.0.
 
 ## Key Conventions
 
-- **Node version**: v22.20.0 (see `.nvmrc`)
+- **Node version**: `lts/jod` (Node 22 LTS; see `.nvmrc`)
 - **Package manager**: Yarn 4.x only — do not use npm or pnpm.
 - TypeScript strict mode is enabled with `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`.
 - Event name constant: `"StepCounter.stepCounterUpdate"` (defined in `NativeStepCounter.ts`).
-- **Timestamp flow**: JS passes `Date.getTime() / 1000` (seconds) to native via `startStepCounterUpdate`. Native returns `startDate`/`endDate` in `StepCountData` as Unix timestamps in **milliseconds**.
+- **Timestamp flow**: JS passes `Date.getTime()` (Unix **milliseconds**) to native via `startStepCounterUpdate`. Native auto-normalizes the incoming value (accepts both milliseconds and seconds) and returns `startDate`/`endDate` in `StepCountData` as Unix timestamps in **milliseconds**.
 - `parseStepData` assumes a daily goal of 10,000 steps and calculates calories as `steps * 0.045 kCal`.
 
 ## Editing Native Code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,9 @@ The [example app](/example/) demonstrates usage of the library. You need to run 
 
 It is configured to use the local version of the library, so any changes you make to the library's source code will be reflected in the example app. Changes to the library's JavaScript code will be reflected in the example app without a rebuild, but native code changes will require a rebuild of the example app.
 
-If you want to use Android Studio or Xcode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/StepCounterExample.xcworkspace` in Xcode and find the source files at `Pods > Development Pods > @dongminyu/react-native-step-counter`.
+If you want to use Android Studio or Xcode to edit the native code, you can open the `example/android` or `example/ios` directories respectively in those editors. To edit the Objective-C or Swift files, open `example/ios/StepCounterExample.xcworkspace` in Xcode and find the source files at `Pods > Development Pods > react-native-step-counter-newarch`.
 
-To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `dongminyu-react-native-step-counter` under `Android`.
+To edit the Java or Kotlin files, open `example/android` in Android studio and find the source files at `react-native-step-counter-newarch` under `Android`.
 
 You can use various commands from the root directory to work with the project.
 

--- a/README.kr.md
+++ b/README.kr.md
@@ -7,11 +7,11 @@ English-speaking developers, please return to the repository main page or click 
 ## 설치 방법
 
 ```shell
-npm install @dongminyu/react-native-step-counter
+npm install react-native-step-counter-newarch
 ```
 
 ```shell
-yarn add @dongminyu/react-native-step-counter
+yarn add react-native-step-counter-newarch
 ```
 
 리액트네이티브 0.60 버전 이후 설치된 네이티브 모듈은 오토 링크됩니다. 네이티브 모듈을 수동으로 연결할 필요가 없습니다.
@@ -100,7 +100,7 @@ import {
   parseStepData,
   startStepCounterUpdate,
   stopStepCounterUpdate,
-} from "@dongminyu/react-native-step-counter";
+} from "react-native-step-counter-newarch";
 ```
 
 `isStepCountingSupported` 메소드를 사용하여 장치에 스텝 카운터 또는 가속도계 센서가 있는지 확인합니다.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This library provides an interface for tracking the number of steps taken by the
 ## Installation
 
 ```shell
-npm install @dongminyu/react-native-step-counter
+npm install react-native-step-counter-newarch
 ```
 
 ```shell
-yarn add @dongminyu/react-native-step-counter
+yarn add react-native-step-counter-newarch
 ```
 
 Native modules will automatically connect after React Native 0.60 version. So you don't need to link the native modules manually.
@@ -101,7 +101,7 @@ import {
   parseStepData,
   startStepCounterUpdate,
   stopStepCounterUpdate,
-} from "@dongminyu/react-native-step-counter";
+} from "react-native-step-counter-newarch";
 ```
 
 Use the `isStepCountingSupported` method to check if the device has a step counter or accelerometer sensor.

--- a/documents/NativeStepCounter.js.html
+++ b/documents/NativeStepCounter.js.html
@@ -29,12 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#NAME">NAME</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
         <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
+        <li><a href="global.html#NAME">NAME</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -72,7 +72,7 @@ export default TurboModuleRegistry.getEnforcing("StepCounter");
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 17:45:51 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/NativeStepCounter.js.html
+++ b/documents/NativeStepCounter.js.html
@@ -29,11 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#NAME">NAME</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
+        <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
+        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -60,7 +61,7 @@ import { TurboModuleRegistry } from "react-native";
  */
 
 export const NAME = "StepCounter";
-export const VERSION = "0.3.0";
+export const VERSION = "0.4.0";
 export const eventName = "StepCounter.stepCounterUpdate";
 export default TurboModuleRegistry.getEnforcing("StepCounter");
 //# sourceMappingURL=NativeStepCounter.js.map</code></pre>
@@ -71,7 +72,7 @@ export default TurboModuleRegistry.getEnforcing("StepCounter");
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun May 24 2026 12:10:58 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/UnavailabilityError.html
+++ b/documents/UnavailabilityError.html
@@ -29,12 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#NAME">NAME</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
         <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
+        <li><a href="global.html#NAME">NAME</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -138,7 +138,7 @@
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 17:45:51 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/UnavailabilityError.html
+++ b/documents/UnavailabilityError.html
@@ -29,11 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#NAME">NAME</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
+        <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
+        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -104,7 +105,8 @@
               <dd class="tag-source">
                 <ul class="dummy">
                   <li>
-                    <a href="index.js.html">index.js</a>, <a href="index.js.html#line74">line 74</a>
+                    <a href="index.js.html">index.js</a>,
+                    <a href="index.js.html#line123">line 123</a>
                   </li>
                 </ul>
               </dd>
@@ -136,7 +138,7 @@
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun May 24 2026 12:10:58 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/global.html
+++ b/documents/global.html
@@ -29,11 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#NAME">NAME</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
+        <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
+        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -113,14 +114,43 @@
 
           <pre
             class="prettyprint"
-          ><code>import { StepCounter } from '@dongminyu/react-native-step-counter';</code></pre>
+          ><code>import { StepCounter } from 'react-native-step-counter-newarch';</code></pre>
 
           <h3 class="subsection-title">Methods</h3>
+
+          <h4 class="name" id="createStepCountFilter">
+            <span class="type-signature"></span>createStepCountFilter<span class="signature"
+              >()</span
+            ><span class="type-signature"></span>
+          </h4>
+
+          <div class="description">
+            <p>Create a stateful filter for live step-count updates.</p>
+            <p>
+              Native pedometer APIs can already include device/OS false positives, and the Android
+              accelerometer fallback can also react to quick hand rotation. This helper drops
+              updates that imply an impossible cadence and rebases later cumulative values so
+              ignored burst steps do not come back on the next event.
+            </p>
+          </div>
+
+          <dl class="details">
+            <dt class="tag-source">Source:</dt>
+            <dd class="tag-source">
+              <ul class="dummy">
+                <li>
+                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line74">line 74</a>
+                </li>
+              </ul>
+            </dd>
+          </dl>
 
           <h4 class="name" id="isStepCountingSupported">
             <span class="type-signature"></span>isStepCountingSupported<span class="signature"
               >()</span
-            ><span class="type-signature"> &rarr; {Promise.&lt;Record.&lt;string, boolean>>}</span>
+            ><span class="type-signature">
+              &rarr; {Promise.&lt;{supported: boolean, granted: boolean}>}</span
+            >
           </h4>
 
           <div class="description">
@@ -135,7 +165,7 @@
             <dd class="tag-source">
               <ul class="dummy">
                 <li>
-                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line90">line 90</a>
+                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line139">line 139</a>
                 </li>
               </ul>
             </dd>
@@ -172,7 +202,7 @@
           <dl class="param-type">
             <dt>Type</dt>
             <dd>
-              <span class="param-type">Promise.&lt;Record.&lt;string, boolean>></span>
+              <span class="param-type">Promise.&lt;{supported: boolean, granted: boolean}></span>
             </dd>
           </dl>
 
@@ -219,7 +249,7 @@
             <dd class="tag-source">
               <ul class="dummy">
                 <li>
-                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line39">line 39</a>
+                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line41">line 41</a>
                 </li>
               </ul>
             </dd>
@@ -307,7 +337,7 @@
             <dd class="tag-source">
               <ul class="dummy">
                 <li>
-                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line112">line 112</a>
+                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line161">line 161</a>
                 </li>
               </ul>
             </dd>
@@ -377,7 +407,7 @@ subscriptionRef.current = startStepCounterUpdate(startDate, (response) => {
             <dd class="tag-source">
               <ul class="dummy">
                 <li>
-                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line132">line 132</a>
+                  <a href="index.js.html">index.js</a>, <a href="index.js.html#line181">line 181</a>
                 </li>
               </ul>
             </dd>
@@ -408,7 +438,7 @@ subscriptionRef.current = startStepCounterUpdate(startDate, (response) => {
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun May 24 2026 12:10:58 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/global.html
+++ b/documents/global.html
@@ -29,12 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#NAME">NAME</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
         <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
+        <li><a href="global.html#NAME">NAME</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -438,7 +438,7 @@ subscriptionRef.current = startStepCounterUpdate(startDate, (response) => {
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 17:45:51 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/index.html
+++ b/documents/index.html
@@ -29,11 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#NAME">NAME</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
+        <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
+        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -57,11 +58,11 @@
           <h2>Installation</h2>
           <pre
             class="prettyprint source lang-shell"
-          ><code>npm install @dongminyu/react-native-step-counter
+          ><code>npm install react-native-step-counter-newarch
 </code></pre>
           <pre
             class="prettyprint source lang-shell"
-          ><code>yarn add @dongminyu/react-native-step-counter
+          ><code>yarn add react-native-step-counter-newarch
 </code></pre>
           <p>
             Native modules will automatically connect after React Native 0.60 version. So you don't
@@ -238,7 +239,7 @@ import {
   parseStepData,
   startStepCounterUpdate,
   stopStepCounterUpdate,
-} from &quot;@dongminyu/react-native-step-counter&quot;;
+} from &quot;react-native-step-counter-newarch&quot;;
 </code></pre>
           <p>
             Use the <code>isStepCountingSupported</code> method to check if the device has a step
@@ -314,7 +315,7 @@ async function startStepCounter() {
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun May 24 2026 12:10:58 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/index.html
+++ b/documents/index.html
@@ -29,12 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#NAME">NAME</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
         <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
+        <li><a href="global.html#NAME">NAME</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -315,7 +315,7 @@ async function startStepCounter() {
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 17:45:51 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/index.js.html
+++ b/documents/index.js.html
@@ -29,12 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#NAME">NAME</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
         <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
+        <li><a href="global.html#NAME">NAME</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -240,7 +240,7 @@ export { NAME, VERSION };
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 17:45:51 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/documents/index.js.html
+++ b/documents/index.js.html
@@ -29,11 +29,12 @@
       </ul>
       <h3>Global</h3>
       <ul>
-        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#NAME">NAME</a></li>
+        <li><a href="global.html#StepCounter">StepCounter</a></li>
+        <li><a href="global.html#createStepCountFilter">createStepCountFilter</a></li>
+        <li><a href="global.html#isStepCountingSupported">isStepCountingSupported</a></li>
         <li><a href="global.html#parseStepData">parseStepData</a></li>
         <li><a href="global.html#startStepCounterUpdate">startStepCounterUpdate</a></li>
-        <li><a href="global.html#StepCounter">StepCounter</a></li>
         <li><a href="global.html#stopStepCounterUpdate">stopStepCounterUpdate</a></li>
       </ul>
     </nav>
@@ -49,7 +50,7 @@ import StepCounterModule, { eventName, NAME, VERSION } from "./NativeStepCounter
 import { NativeEventEmitter, Platform } from "react-native";
 
 /* A way to check if the module is linked. */
-const LINKING_ERROR = "The package '@dongminyu/react-native-step-counter' doesn't seem to be linked. Make sure: \n\n" + Platform.select({
+const LINKING_ERROR = "The package 'react-native-step-counter-newarch' doesn't seem to be linked. Make sure: \n\n" + Platform.select({
   ios: "- You have run `pod install` in the `ios` directory and then clean, rebuild and re-run the app. You may also need to re-open Xcode to get the new pods.\n",
   android: "- You have the Android development environment set up: `https://reactnative.dev/docs/environment-setup.`",
   default: ""
@@ -62,7 +63,7 @@ const LINKING_ERROR = "The package '@dongminyu/react-native-step-counter' doesn'
  * counterType - The type of counter used to count the steps.
  * @throws {Error} LINKING_ERROR - Throws Error If global variable turboModuleProxy is undefined.
  * @example
- * import { StepCounter } from '@dongminyu/react-native-step-counter';
+ * import { StepCounter } from 'react-native-step-counter-newarch';
  */
 const StepCounter = StepCounterModule ? StepCounterModule : new Proxy({}, {
   get() {
@@ -70,6 +71,8 @@ const StepCounter = StepCounterModule ? StepCounterModule : new Proxy({}, {
   }
 });
 const StepEventEmitter = new NativeEventEmitter(StepCounter);
+const DEFAULT_MINIMUM_STEP_INTERVAL_MS = 250;
+
 // Tracks the subscription created by the most recent startStepCounterUpdate call.
 // Only this subscription is removed in stopStepCounterUpdate, so that external
 // subscribers (e.g. debug log components) are not unintentionally removed.
@@ -107,6 +110,53 @@ export function parseStepData(data) {
 }
 
 /**
+ * Create a stateful filter for live step-count updates.
+ *
+ * Native pedometer APIs can already include device/OS false positives, and the
+ * Android accelerometer fallback can also react to quick hand rotation. This
+ * helper drops updates that imply an impossible cadence and rebases later
+ * cumulative values so ignored burst steps do not come back on the next event.
+ */
+export function createStepCountFilter(options = {}) {
+  const minimumStepIntervalMs = options.minimumStepIntervalMs &amp;&amp; options.minimumStepIntervalMs > 0 ? options.minimumStepIntervalMs : DEFAULT_MINIMUM_STEP_INTERVAL_MS;
+  let previousRawData = null;
+  let ignoredSteps = 0;
+  let ignoredDistance = 0;
+  return data => {
+    if (!Number.isFinite(data.steps) || data.steps &lt; 0) {
+      return null;
+    }
+    if (previousRawData &amp;&amp; data.steps &lt; previousRawData.steps) {
+      previousRawData = data;
+      ignoredSteps = 0;
+      ignoredDistance = 0;
+      return data;
+    }
+    const referenceTime = previousRawData ? previousRawData.endDate : data.startDate;
+    const stepDelta = previousRawData ? data.steps - previousRawData.steps : data.steps;
+    const distanceDelta = previousRawData ? data.distance - previousRawData.distance : data.distance;
+    const elapsedMs = Number.isFinite(data.endDate) &amp;&amp; Number.isFinite(referenceTime) ? data.endDate - referenceTime : Number.POSITIVE_INFINITY;
+    const isSuspiciousBurst = stepDelta > 0 &amp;&amp; elapsedMs >= 0 &amp;&amp; elapsedMs &lt; stepDelta * minimumStepIntervalMs;
+    previousRawData = data;
+    if (isSuspiciousBurst) {
+      ignoredSteps += stepDelta;
+      if (distanceDelta > 0) {
+        ignoredDistance += distanceDelta;
+      }
+      return null;
+    }
+    if (ignoredSteps === 0 &amp;&amp; ignoredDistance === 0) {
+      return data;
+    }
+    return {
+      ...data,
+      steps: Math.max(0, data.steps - ignoredSteps),
+      distance: Math.max(0, data.distance - ignoredDistance)
+    };
+  };
+}
+
+/**
  * If you're using a method or property that's not available on the current platform, throw this error.
  * @param {string} moduleName The name of the module.
  * @param {string} propertyName The name of the property.
@@ -128,7 +178,7 @@ class UnavailabilityError extends Error {
  * iOS 8.0+ only. Android is available since KitKat (4.4 / API 19).
  * @see https://developer.android.com/about/versions/android-4.4.html
  * @see https://developer.apple.com/documentation/coremotion/cmpedometer/1613963-isstepcountingavailable
- * @returns {Promise&lt;Record&lt;string, boolean>>} A promise that resolves with an object containing the stepCounter availability.
+ * @returns {Promise&lt;{ supported: boolean, granted: boolean }>} A promise that resolves with an object containing the stepCounter availability.
  * supported - Whether the stepCounter is supported on device.
  * granted - Whether user granted the permission.
  */
@@ -190,7 +240,7 @@ export { NAME, VERSION };
     <br class="clear" />
 
     <footer>
-      Documentation generated at Sun May 24 2026 12:10:58 GMT+0900 (Korean Standard Time)
+      Documentation generated at Sun Jul 12 2026 16:00:14 GMT+0900 (Korean Standard Time)
     </footer>
 
     <script>

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2068,7 +2068,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - StepCounter (0.4.0):
+  - StepCounter (0.5.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2417,7 +2417,7 @@ SPEC CHECKSUMS:
   RNReanimated: 59bf185693b7294a0c515e19a6d1be54def61363
   RNSVG: a37350c7bc37452fd2b209efa0806f1de0f847ae
   RNWorklets: 32b9ca9e0588b838ce3202a9ea3971f553c9011c
-  StepCounter: 31024436290466609cdc216287ca9c7190ba099d
+  StepCounter: f17e2184888b06b1d1f81d3645ef1561c4ed06bc
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 
 PODFILE CHECKSUM: cc844e779d2f3a18b09e701a6bedf73e1a9a94c6

--- a/example/osv-scanner.toml
+++ b/example/osv-scanner.toml
@@ -12,12 +12,15 @@
 # Recorded 2026-07-12.
 [[IgnoredVulns]]
 id = "GHSA-h8w8-99g7-qmvj"
+ignoreUntil = 2026-10-01
 reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."
 
 [[IgnoredVulns]]
 id = "GHSA-6wx8-w4f5-wwcr"
+ignoreUntil = 2026-10-01
 reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."
 
 [[IgnoredVulns]]
 id = "GHSA-wv3x-4vxv-whpp"
+ignoreUntil = 2026-10-01
 reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."

--- a/example/osv-scanner.toml
+++ b/example/osv-scanner.toml
@@ -1,0 +1,23 @@
+# OSV-Scanner ignore list.
+# Each entry is a vulnerability that cannot currently be remediated by an
+# upgrade in this repository. Include a date so entries do not go stale.
+
+# concurrent-ruby (example/Gemfile.lock) is pinned to `< 1.3.4` in
+# `example/Gemfile` to avoid known CocoaPods / activesupport build failures.
+# The advisories below are all fixed in concurrent-ruby 1.3.7, but that pin
+# blocks the upgrade. This gem is part of the example app's iOS build tooling
+# (Ruby/CocoaPods) and is NOT shipped in the published npm package. Re-evaluate
+# by bumping the `< 1.3.4` pin to `>= 1.3.7` and running `bundle update` in the
+# iOS environment (the Gemfile already declares `logger`, the usual blocker).
+# Recorded 2026-07-12.
+[[IgnoredVulns]]
+id = "GHSA-h8w8-99g7-qmvj"
+reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."
+
+[[IgnoredVulns]]
+id = "GHSA-6wx8-w4f5-wwcr"
+reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."
+
+[[IgnoredVulns]]
+id = "GHSA-wv3x-4vxv-whpp"
+reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,7 +16,7 @@ import {
   startStepCounterUpdate,
   stopStepCounterUpdate,
   type StepCountData,
-} from "@dongminyu/react-native-step-counter";
+} from "react-native-step-counter-newarch";
 import { getStepCounterPermission } from "./permission";
 import CircularProgress, { type ProgressRef } from "react-native-circular-progress-indicator";
 import LogCat, { type LogLine } from "./LogCat";

--- a/example/src/__tests__/App.test.tsx
+++ b/example/src/__tests__/App.test.tsx
@@ -3,7 +3,7 @@ import App from "../App";
 
 // ─── mocks ──────────────────────────────────────────────────────────────────
 
-jest.mock("@dongminyu/react-native-step-counter", () => ({
+jest.mock("react-native-step-counter-newarch", () => ({
   createStepCountFilter: jest.fn(() => (data: unknown) => data),
   isStepCountingSupported: jest.fn(),
   startStepCounterUpdate: jest.fn(),
@@ -29,7 +29,7 @@ import {
   isStepCountingSupported,
   startStepCounterUpdate,
   stopStepCounterUpdate,
-} from "@dongminyu/react-native-step-counter";
+} from "react-native-step-counter-newarch";
 import { getStepCounterPermission } from "../permission";
 
 const mockSupported = isStepCountingSupported as jest.Mock;

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
     "^react-native$": "<rootDir>/node_modules/react-native",
     "^react-native/(.*)": "<rootDir>/node_modules/react-native/$1",
     // Map the local library to source so example tests can import it
-    "^@dongminyu/react-native-step-counter$": "<rootDir>/src/index.tsx",
+    "^react-native-step-counter-newarch$": "<rootDir>/src/index.tsx",
     // Mock native packages from example/node_modules
     "^react-native-svg$": "<rootDir>/__mocks__/react-native-svg.tsx",
     "^react-native-safe-area-context$": "<rootDir>/__mocks__/react-native-safe-area-context.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-step-counter-newarch",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "This library provides an interface for tracking the number of steps taken by the user in a React Native app.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dongminyu/react-native-step-counter",
+  "name": "react-native-step-counter-newarch",
   "version": "0.4.0",
   "description": "This library provides an interface for tracking the number of steps taken by the user in a React Native app.",
   "main": "./lib/module/index.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@babel/core": "^7.29.0",
+    "@babel/core": "^7.29.6",
     "@react-native/babel-preset": "0.85.3",
     "@react-native/jest-preset": "0.85.3",
     "@release-it/conventional-changelog": "^11.0.0",
@@ -77,6 +77,7 @@
     "typescript": "^6.0.3"
   },
   "resolutions": {
+    "@babel/core": "7.29.7",
     "basic-ftp": "5.3.1",
     "brace-expansion@npm:^1.1.7": "npm:1.1.13",
     "brace-expansion@npm:^2.0.1": "npm:2.0.3",
@@ -85,6 +86,10 @@
     "fast-xml-parser": "5.7.0",
     "handlebars@npm:^4.7.7": "npm:4.7.9",
     "ip-address@npm:^10.0.1": "npm:10.1.1",
+    "joi@npm:^17.2.1": "17.13.4",
+    "js-yaml@npm:^3.13.1": "3.15.0",
+    "js-yaml@npm:^4.1.0": "4.2.0",
+    "launch-editor@npm:^2.9.1": "2.14.1",
     "minimatch@npm:^10.2.1": "npm:10.2.3",
     "minimatch@npm:^3.0.4": "npm:3.1.4",
     "minimatch@npm:^3.1.1": "npm:3.1.4",
@@ -93,7 +98,12 @@
     "picomatch@npm:^2.2.3": "npm:2.3.2",
     "picomatch@npm:^2.3.1": "npm:2.3.2",
     "picomatch@npm:^4.0.3": "npm:4.0.4",
-    "tar": "7.5.13",
+    "shell-quote": "1.8.4",
+    "tar": "7.5.16",
+    "undici@npm:7.24.5": "7.28.0",
+    "ws@npm:^6.2.3": "6.2.4",
+    "ws@npm:^7": "7.5.11",
+    "ws@npm:^7.5.10": "7.5.11",
     "yaml@npm:^2.2.1": "npm:2.8.3",
     "yaml@npm:^2.6.1": "npm:2.8.3"
   },

--- a/src/NativeStepCounter.ts
+++ b/src/NativeStepCounter.ts
@@ -31,7 +31,7 @@ export interface Spec extends TurboModule {
   /**
    * @description Check if the step counter is supported on the device.
    * @async
-   * @returns {Promise<{ supported: boolean; granted: boolean }>} Returns the `Promise` object,
+   * @returns {Promise<{ supported: boolean, granted: boolean }>} Returns the `Promise` object,
    * including information such as whether the user's device has a step counter sensor by default (`supported`)
    * and whether the user has allowed the app to measure the pedometer data. (`granted`)
    * granted - The permission is granted or not.

--- a/src/NativeStepCounter.ts
+++ b/src/NativeStepCounter.ts
@@ -24,7 +24,7 @@ export type StepCountData = {
 };
 
 export const NAME = "StepCounter";
-export const VERSION = "0.4.0";
+export const VERSION = "0.5.0";
 export const eventName = "StepCounter.stepCounterUpdate";
 
 export interface Spec extends TurboModule {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -49,8 +49,8 @@ describe("exported constants", () => {
     expect(NAME).toBe("StepCounter");
   });
 
-  it('VERSION is "0.4.0"', () => {
-    expect(VERSION).toBe("0.4.0");
+  it('VERSION is "0.5.0"', () => {
+    expect(VERSION).toBe("0.5.0");
   });
 
   it('eventName is "StepCounter.stepCounterUpdate"', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import { NativeEventEmitter, Platform } from "react-native";
 
 /* A way to check if the module is linked. */
 const LINKING_ERROR =
-  "The package '@dongminyu/react-native-step-counter' doesn't seem to be linked. Make sure: \n\n" +
+  "The package 'react-native-step-counter-newarch' doesn't seem to be linked. Make sure: \n\n" +
   Platform.select({
     ios: "- You have run `pod install` in the `ios` directory and then clean, rebuild and re-run the app. You may also need to re-open Xcode to get the new pods.\n",
     android:
@@ -44,7 +44,7 @@ export interface ParsedStepCountData {
  * counterType - The type of counter used to count the steps.
  * @throws {Error} LINKING_ERROR - Throws Error If global variable turboModuleProxy is undefined.
  * @example
- * import { StepCounter } from '@dongminyu/react-native-step-counter';
+ * import { StepCounter } from 'react-native-step-counter-newarch';
  */
 const StepCounter = (
   StepCounterModule

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -196,7 +196,7 @@ class UnavailabilityError extends Error {
  * iOS 8.0+ only. Android is available since KitKat (4.4 / API 19).
  * @see https://developer.android.com/about/versions/android-4.4.html
  * @see https://developer.apple.com/documentation/coremotion/cmpedometer/1613963-isstepcountingavailable
- * @returns {Promise<{ supported: boolean; granted: boolean }>} A promise that resolves with an object containing the stepCounter availability.
+ * @returns {Promise<{ supported: boolean, granted: boolean }>} A promise that resolves with an object containing the stepCounter availability.
  * supported - Whether the stepCounter is supported on device.
  * granted - Whether user granted the permission.
  */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
-      "@dongminyu/react-native-step-counter": ["./src/index"]
+      "react-native-step-counter-newarch": ["./src/index"]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/169fc2080169a40c1760155eaaaf739bcb882df0bec76a83adbda5493645bc17270a3434b8848c494b1933e96fe1d147370001e3cda09a39f43ae30f08ef2069
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.28.6":
   version: 7.29.0
   resolution: "@babel/compat-data@npm:7.29.0"
@@ -46,26 +57,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.23.9, @babel/core@npm:^7.25.2, @babel/core@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/core@npm:7.29.0"
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 10c0/47913f05e08a45a1c9df38c02b4b49e391005085b489432647a1abe112e5d9c75e3be8ea5972b7f6da4ec5d1339922ceb9ea02b8a25d4ed1cb8636e5261f344e
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:7.29.7":
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
   dependencies:
-    "@babel/code-frame": "npm:^7.29.0"
-    "@babel/generator": "npm:^7.29.0"
-    "@babel/helper-compilation-targets": "npm:^7.28.6"
-    "@babel/helper-module-transforms": "npm:^7.28.6"
-    "@babel/helpers": "npm:^7.28.6"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/traverse": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-compilation-targets": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helpers": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
     "@jridgewell/remapping": "npm:^2.3.5"
     convert-source-map: "npm:^2.0.0"
     debug: "npm:^4.1.0"
     gensync: "npm:^1.0.0-beta.2"
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
-  checksum: 10c0/5127d2e8e842ae409e11bcbb5c2dff9874abf5415e8026925af7308e903f4f43397341467a130490d1a39884f461bc2b67f3063bce0be44340db89687fd852aa
+  checksum: 10c0/112fb09c24de7a1de64d1de2c31fe65c4e6af4cb2fb6e6d99ea5373e6fc51e75b88581c0efae4c4c68f119a02a988c7106e95011a41530a2fb8ed793c7eaa07b
   languageName: node
   linkType: hard
 
@@ -79,6 +97,19 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
   checksum: 10c0/349086e6876258ef3fb2823030fee0f6c0eb9c3ebe35fc572e16997f8c030d765f636ddc6299edae63e760ea6658f8ee9a2edfa6d6b24c9a80c917916b973551
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
+  dependencies:
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/9bf72b01b5bd0ea5b1288a0e37dbd360bff2f2b1ce73342c0d40fb3db2ec3dc004ada5ffa925c5e12939a416eed59e600d562b8ecd938ce0d27dfd0eb6c6c2b7
   languageName: node
   linkType: hard
 
@@ -101,6 +132,19 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: 10c0/3fcdf3b1b857a1578e99d20508859dbd3f22f3c87b8a0f3dc540627b4be539bae7f6e61e49d931542fe5b557545347272bbdacd7f58a5c77025a18b745593a50
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
+  dependencies:
+    "@babel/compat-data": "npm:^7.29.7"
+    "@babel/helper-validator-option": "npm:^7.29.7"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/4c15fd4c69a0a7047799a28a88460c19cede0a0ee8af994ea169114986f4af48b92c7393a4a3fee0456c11a656eece3448a6ed06354453d6c27cccf17195453b
   languageName: node
   linkType: hard
 
@@ -156,6 +200,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 10c0/f38417c40b1129a1b2b519ca961b9040c8827d1444fd74068702286b91b77089431dc76b6b9d5c1496e5da2a4f3ad329c6946e688ba3fa0d1d0b3d2b4f34f36a
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-member-expression-to-functions@npm:7.28.5"
@@ -176,6 +227,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/6adf60d97356027413342a092f818d9678c4f5caff716a33e3284b5ae14e47a9e88059d421dde4ee4894691260039a12602c0e7becadc175602194b40dfa345d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/helper-module-transforms@npm:7.28.6"
@@ -186,6 +247,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10c0/6f03e14fc30b287ce0b839474b5f271e72837d0cafe6b172d759184d998fbee3903a035e81e07c2c596449e504f453463d58baa65b6f40a37ded5bec74620b2b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10c0/ee5a2172c24a42be696836f4b0d947489c9729d8adf5821885cf77d1ad5333e3c447368e9a71f67df1099570490553dccf9f888ef0a92a48aa63cb086bd8c7e1
   languageName: node
   linkType: hard
 
@@ -248,6 +322,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10c0/194bc0f1716e396d5ffde56ad6119745fb9557662c98611590e5e454906783a4ccb21ce93056b8eb69a4909044834e45d96e50ac695bbe9e3221648fe033c06c
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
@@ -255,10 +336,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
   checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: 10c0/d2a06c6d0ac40ba4a2f219fc2cab249c7a94bacdb2686273b7f9598571c908809b48468ff588915a346e6cc7296f60b581023d1d498b747fed06f779d335c2cc
   languageName: node
   linkType: hard
 
@@ -273,13 +368,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.28.6":
-  version: 7.28.6
-  resolution: "@babel/helpers@npm:7.28.6"
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
   dependencies:
-    "@babel/template": "npm:^7.28.6"
-    "@babel/types": "npm:^7.28.6"
-  checksum: 10c0/c4a779c66396bb0cf619402d92f1610601ff3832db2d3b86b9c9dd10983bf79502270e97ac6d5280cea1b1a37de2f06ecbac561bd2271545270407fbe64027cb
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/218e8d10953647c9f44775f5a022b227a182674853b5ea8631889deb7e1a3e4bc870388aaecf59bb8bd92a87f9a96220ed3f70a35bffec6bcf9169ecb67891ac
   languageName: node
   linkType: hard
 
@@ -302,6 +397,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/f06920c819550c0db689e4c5b626bf55ba3cebf80ebe9ccfa434e134036cf3de50951fe759f74abb2dae381989239860bde46d4600328578ad1f7114c3711a6d
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/65133038f80b54a714d6027cb77cee3f9a6b5c4c6842ce674301e13947cbcbfa8055e63acaf1b84c085d34226a14425b2c2b97b829e0e226d2e8f1299942a51d
   languageName: node
   linkType: hard
 
@@ -1515,6 +1621,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/8bb7f900dcab0e9e1c5ffbc33ca10e0d26b7b2e2ca804becb73ee771b9c4ed6e2908a4ae4a14c08560febb45d2b6b9a173955e42ad404d05f8b04840a14d9c58
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.5, @babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/traverse@npm:7.29.0"
@@ -1530,6 +1647,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/e256a1fbdb956555b76f3c285b1e453f6bedec8b3afb61751d99d933efd11c7d79caf5ddf2493570058a9f7deaa1b48324380d7c1aa1443fd9508becbf56331a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.5, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
   version: 7.29.0
   resolution: "@babel/types@npm:7.29.0"
@@ -1537,6 +1669,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10c0/b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
   languageName: node
   linkType: hard
 
@@ -6512,16 +6654,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"joi@npm:^17.2.1":
-  version: 17.13.3
-  resolution: "joi@npm:17.13.3"
+"joi@npm:17.13.4":
+  version: 17.13.4
+  resolution: "joi@npm:17.13.4"
   dependencies:
     "@hapi/hoek": "npm:^9.3.0"
     "@hapi/topo": "npm:^5.1.0"
     "@sideway/address": "npm:^4.1.5"
     "@sideway/formula": "npm:^3.0.1"
     "@sideway/pinpoint": "npm:^2.0.0"
-  checksum: 10c0/9262aef1da3f1bec5b03caf50c46368899fe03b8ff26cbe3d53af4584dd1049079fc97230bbf1500b6149db7cc765b9ee45f0deb24bb6fc3fa06229d7148c17f
+  checksum: 10c0/5addfef638e90eb6a45a72e3884128d8d9a80c487cb8bfcb949be179b875ad1095af347fa1bd05c4ebec2b2ccbc3f3db5f34501c8672ecd16100de2b77087122
   languageName: node
   linkType: hard
 
@@ -6532,26 +6674,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+"js-yaml@npm:3.15.0":
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
+  checksum: 10c0/ca966bd354ac5b1b7a4694ebdba46526796aa3a6a99529fa540af2abf85918bd155a50ccc0166b413130a00622999973754458ec01e7095bc902177bfdbd5b64
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:4.2.0":
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
   languageName: node
   linkType: hard
 
@@ -6626,13 +6768,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"launch-editor@npm:^2.9.1":
-  version: 2.13.0
-  resolution: "launch-editor@npm:2.13.0"
+"launch-editor@npm:2.14.1":
+  version: 2.14.1
+  resolution: "launch-editor@npm:2.14.1"
   dependencies:
     picocolors: "npm:^1.1.1"
-    shell-quote: "npm:^1.8.3"
-  checksum: 10c0/7c4a42d5271f286df82e0078e8fd84f38a0ec6e89d8203d31257dbbef6d93f842e0fb4c4c7ff4f9f016cfc5143a06de82778dfb05eab10be83bbf39dfef2d96e
+    shell-quote: "npm:^1.8.4"
+  checksum: 10c0/bb0ab182086afaf1c391abd38d6fc9d5391cb43d0c2da1d96176f79e9995635cdf34dcfd8df3f756bb82d7bbbb7d37014d5eb312f337350889c0cff92db53dab
   languageName: node
   linkType: hard
 
@@ -8301,7 +8443,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-step-counter-newarch@workspace:."
   dependencies:
-    "@babel/core": "npm:^7.29.0"
+    "@babel/core": "npm:^7.29.6"
     "@react-native/babel-preset": "npm:0.85.3"
     "@react-native/jest-preset": "npm:0.85.3"
     "@release-it/conventional-changelog": "npm:^11.0.0"
@@ -8827,10 +8969,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+"shell-quote@npm:1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 
@@ -9260,16 +9402,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.13":
-  version: 7.5.13
-  resolution: "tar@npm:7.5.13"
+"tar@npm:7.5.16":
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 
@@ -9458,10 +9600,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:7.24.5":
-  version: 7.24.5
-  resolution: "undici@npm:7.24.5"
-  checksum: 10c0/2a836f1f6ab078fde3eeb4cc8fd5b34eeaf52cfbdf16a9bab61b7223f43f7847bcd2125d1da7c4e3f5996c528bf9f7940015d39909bab80cfbd71b855470cf21
+"undici@npm:7.28.0":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 
@@ -9753,18 +9895,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^6.2.3":
-  version: 6.2.3
-  resolution: "ws@npm:6.2.3"
+"ws@npm:6.2.4":
+  version: 6.2.4
+  resolution: "ws@npm:6.2.4"
   dependencies:
     async-limiter: "npm:~1.0.0"
-  checksum: 10c0/56a35b9799993cea7ce2260197e7879f21bbbb194a967f31acbbda6f7f46ecda4365951966fb062044c95197e19fb2f053be6f65c172435455186835f494de41
+  checksum: 10c0/5c2b9474164f9cb68c7776a1d10b0461c186f3a69bffb1028fca33eba5ab7206a09173fb0b311d6c5a81c8cf148406f8deb0b7d899542ab8ca67407d99717dad
   languageName: node
   linkType: hard
 
-"ws@npm:^7, ws@npm:^7.5.10":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
+"ws@npm:7.5.11":
+  version: 7.5.11
+  resolution: "ws@npm:7.5.11"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -9773,7 +9915,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  checksum: 10c0/7972670b676fb1ccba73b0899ca3c2e04e8c2075629c2614cced7f556536f96a672bbf4619fc5a06c8b8720bb839a47ca88c69c95dc14c9c61a99fbecba1c866
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,33 +1585,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dongminyu/react-native-step-counter@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@dongminyu/react-native-step-counter@workspace:."
-  dependencies:
-    "@babel/core": "npm:^7.29.0"
-    "@react-native/babel-preset": "npm:0.85.3"
-    "@react-native/jest-preset": "npm:0.85.3"
-    "@release-it/conventional-changelog": "npm:^11.0.0"
-    "@testing-library/react-native": "npm:^13.3.3"
-    "@types/babel__core": "npm:^7.20.5"
-    "@types/jest": "npm:^29.5.14"
-    "@types/react": "npm:^19.2.15"
-    "@types/react-test-renderer": "npm:^19.1.0"
-    del-cli: "npm:^7.0.0"
-    jest: "npm:^29.7.0"
-    react: "npm:19.2.3"
-    react-native: "npm:0.85.3"
-    react-native-builder-bob: "npm:^0.41.0"
-    react-test-renderer: "npm:19.2.3"
-    release-it: "npm:^20.0.1"
-    typescript: "npm:^6.0.3"
-  peerDependencies:
-    react: "*"
-    react-native: ">=0.71.0"
-  languageName: unknown
-  linkType: soft
-
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -8323,6 +8296,33 @@ __metadata:
   checksum: 10c0/86d1375ce17d549b541d157148d9d093f9e918de47d3b0a5cbc4cb6afe619aa52e99f07dc62ee0878eaa70e8da3411193b24cfee1b7b271ffd295d0fce83d128
   languageName: node
   linkType: hard
+
+"react-native-step-counter-newarch@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "react-native-step-counter-newarch@workspace:."
+  dependencies:
+    "@babel/core": "npm:^7.29.0"
+    "@react-native/babel-preset": "npm:0.85.3"
+    "@react-native/jest-preset": "npm:0.85.3"
+    "@release-it/conventional-changelog": "npm:^11.0.0"
+    "@testing-library/react-native": "npm:^13.3.3"
+    "@types/babel__core": "npm:^7.20.5"
+    "@types/jest": "npm:^29.5.14"
+    "@types/react": "npm:^19.2.15"
+    "@types/react-test-renderer": "npm:^19.1.0"
+    del-cli: "npm:^7.0.0"
+    jest: "npm:^29.7.0"
+    react: "npm:19.2.3"
+    react-native: "npm:0.85.3"
+    react-native-builder-bob: "npm:^0.41.0"
+    react-test-renderer: "npm:19.2.3"
+    release-it: "npm:^20.0.1"
+    typescript: "npm:^6.0.3"
+  peerDependencies:
+    react: "*"
+    react-native: ">=0.71.0"
+  languageName: unknown
+  linkType: soft
 
 "react-native-svg@npm:^15.15.5":
   version: 15.15.5


### PR DESCRIPTION
Release **v0.5.0** (`0.4.0` → `0.5.0`, minor).

> Version chosen as `minor` (not the `major` that the `refactor(pkg)!:` rename would imply under strict conventional-commits) to keep the `0.x` line consistent with the sibling-library rename convention.

### ⚠ BREAKING CHANGES

- 📦 **Package renamed to `react-native-step-counter-newarch`** (previously `@dongminyu/react-native-step-counter`). Update your dependency and every import path. The unscoped `react-native-step-counter` name is blocked by npm's name-similarity check (it normalizes to the same string as the 2016 `react-native-stepcounter` fork of `react-native-pedometer`), so the New Architecture identity is signaled with a `-newarch` suffix. The GitHub repository is unchanged.

### Bug Fixes

- 🐛 **JSDoc type parsing**: Corrected the `@returns` inline object type in the doc comments (`;` → `,`) so `jsdoc` can parse the type expression and generate the API documentation.

### Documentation

- 📝 **Knowledge layer reconciled**: Aligned `CLAUDE.md`, `AGENTS.md`, and the Serena memory files with the current code — public API surface, Jest preset, Node channel, React Native peer range, and the timestamp flow.
- 📝 Regenerated the JSDoc API documentation.

### Chore Changes

- 🔨 Quoted the `NODE_BINARY` command in the iOS example build for consistency.
- 👷 Added native Android and iOS example build workflows.

---

- Tag `v0.5.0` is already pushed.
- **Not published to npm** yet — this run stops at tag + PR. First publish under the new name `react-native-step-counter-newarch` is pending.
- ⚠️ `main` requires **signed commits** — merge via **squash or merge-commit** (GitHub-signed), not rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Released v0.5.0 under the new package identity `react-native-step-counter-newarch`, updating dependency/import aliases, TypeScript path mappings, Jest module resolution, and consumer docs/examples to enforce the intended New Architecture upgrade path and prevent users from wiring the wrong package/module.
- Added/updated `createStepCountFilter` to stabilize live step-count streams by filtering implausible burst deltas and rebasing cumulative totals, reducing false step changes and improving runtime correctness for consumer apps.
- Fixed JSDoc return-type object typing (e.g., `isStepCountingSupported`) and regenerated the published API documentation/knowledge artifacts so consumer-visible types and guidance match the actual exported surface and lower integration/type-compatibility risk.
- Strengthened the release and verification experience by quoting the iOS `NODE_BINARY` usage for consistency, adding native Android/iOS example build workflows, and including dependency/security housekeeping plus an OSV ignore entry to keep the dependency footprint predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->