### PR TITLE
fix(deps): drop concurrent-ruby pin to patch GHSA advisories

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby ">= 2.6.10"
+ruby ">= 3.1.0"
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -7,7 +7,6 @@ ruby ">= 2.6.10"
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.3.3)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     drb (2.2.3)
     escape (0.0.4)
@@ -109,7 +109,6 @@ DEPENDENCIES
   benchmark
   bigdecimal
   cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
-  concurrent-ruby (< 1.3.4)
   logger
   mutex_m
   nkf
@@ -134,7 +133,7 @@ CHECKSUMS
   cocoapods-trunk (1.6.0) sha256=5f5bda8c172afead48fa2d43a718cf534b1313c367ba1194cebdeb9bfee9ed31
   cocoapods-try (1.2.0) sha256=145b946c6e7747ed0301d975165157951153d27469e6b2763c83e25c84b9defe
   colored2 (3.1.2) sha256=b13c2bd7eeae2cf7356a62501d398e72fde78780bd26aec6a979578293c28b4a
-  concurrent-ruby (1.3.3) sha256=4f9cd28965c4dcf83ffd3ea7304f9323277be8525819cb18a3b61edcb56a7c6a
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   escape (0.0.4) sha256=e49f44ae2b4f47c6a3abd544ae77fe4157802794e32f19b8e773cbc4dcec4169

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2344,82 +2344,82 @@ SPEC CHECKSUMS:
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
-  RCTSwiftUIWrapper: 7b8a1ffba8994a8f955c563511bffb74b4681317
+  RCTSwiftUIWrapper: 966ca7f5f22ac0b2b2255fb09cffc381f5440b03
   RCTTypeSafety: 2a6403ba3492c04510e7c15bd635461646c43bb2
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
-  React-Core: f90d375d3bab515ad00df30605ce1bf02e6db12f
+  React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
   React-Core-prebuilt: 929d85171bd5ae75faa8685b047c8ae79596aa9d
-  React-CoreModules: da4f80202ef954bdfb926ca4c9ac5f685900aa5c
-  React-cxxreact: 1d1d2a28a5f10e4e2e7cf2bfd54dc9c92c68c672
+  React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
+  React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
-  React-defaultsnativemodule: 172d2ef7d11c531c40ee74f3be1ac98d258a817f
-  React-domnativemodule: 5a60a88075a35e20fa5879c94e7aa24e5f4071d0
-  React-Fabric: 5c1954e06c094623e46d51da2dc2c926621c03a5
-  React-FabricComponents: f32494150868073accd5d52d46b30a0496626813
-  React-FabricImage: dfcd2826b10f05c19e5bfa68d4937c4401c129db
-  React-featureflags: 84bcfcb8f91f9475e437f3dd579399085a4af51e
-  React-featureflagsnativemodule: 83111c4ee188b8859aaa8643c1be640442098fef
-  React-graphics: e0441bc695f5c682a3fb1b0fd317e10765700f12
-  React-hermes: da795ff5d5816d8940fca927c46dcdd81d7e9ad6
-  React-idlecallbacksnativemodule: b6d79e1c9e335564e17d18e2649fe7524c4e74e4
-  React-ImageManager: 0e137d7231092ddaa236f3520b67b4aa833e7079
-  React-intersectionobservernativemodule: 160b3c85bb5a3df2bf50e60619c0db50aadbef8c
-  React-jserrorhandler: 619d382632f5ed166541c03f7ba7deee76fb1b16
-  React-jsi: eac528e72d25146faa922ef1aad82d338addbb75
-  React-jsiexecutor: 2d3000fdde95d0da451f8976cdf9018448756023
-  React-jsinspector: 0377987f9635c64c5aaf72ec73aaf2b0b0da7744
-  React-jsinspectorcdp: 9db641a9cd0dd5b693df27d2e665ac2540ddc336
-  React-jsinspectornetwork: 61b00d0adfe6f175830660f1b98da576bc74eb0a
-  React-jsinspectortracing: 0f8d4f2ebd7523aece78cbc926cd4b6f2fc227dc
-  React-jsitooling: 36f3854063d507bc4d4a01227ebf1b63d9e24592
-  React-jsitracing: cddf044c0c2847d3f5822a984018fd5596c1d448
-  React-logger: 57001aefabd79d885589d2f31a8be05ccc393eaa
-  React-Mapbuffer: 1aa9126122d4247ffc24bf9d28d50ce923499a71
-  React-microtasksnativemodule: d86581169e9bb5bb6f5fc3c5052f890016c1bf21
-  React-mutationobservernativemodule: 9a0c4e866f1ef2a57acebc902ebacbdf469ae741
-  react-native-safe-area-context: c1eb308f4b36372a4de4b3bdaa8ed695ec3dd461
-  React-NativeModulesApple: cc6ec4767844d610e92cc358bd3ea34937438d56
-  React-networking: a8ce15641ed7775d5b54a9d0d32defc367c2216e
+  React-defaultsnativemodule: cd64bc09d7ca24112bbaf1b91edbbcf3d81ea7dc
+  React-domnativemodule: dacf5bc055ae041039574f38b73a20b91e368774
+  React-Fabric: bb0baa33d91839631d315800eb23e9aaa4338a44
+  React-FabricComponents: c504d0b0e2f3054b2ba19af839f175cb361153c0
+  React-FabricImage: 91eaea1cc58d25ae2596a9277bcfe028f92374c3
+  React-featureflags: 5ac0455da0af12ca79b40402e2f42c5c7556b638
+  React-featureflagsnativemodule: df7da181b064f10f5959a7cd529b5aab3686ecb2
+  React-graphics: d25b1195baf24c7918543f4aff9be89cc080906f
+  React-hermes: 663286153a8ad6bf752b742654c766ff5e8991e7
+  React-idlecallbacksnativemodule: 0bd5392cb67f1ab25df736814b7c05213b1d3c68
+  React-ImageManager: a03eed3e3d4222130dc0ad503a1a5f3aa89de746
+  React-intersectionobservernativemodule: 5d0f1c3c7b30031b0f6f730ee52dd9d607e2c966
+  React-jserrorhandler: d5d6e7e20c5a2d6e8607e18d31d8712d7de676f6
+  React-jsi: eb7cc4cffcf24796cc302d5b2bca0e92544139a9
+  React-jsiexecutor: 65006f60e64c72c6b82f62ef6bd17c84846e73f8
+  React-jsinspector: 01e32e2247b2486117fbb143db7f7717ef462c6d
+  React-jsinspectorcdp: f1cbb34ca41d188ba22efd9b663cf258a911f6cd
+  React-jsinspectornetwork: f61acc94c881c41451f508abfe6efa748b956c21
+  React-jsinspectortracing: 9395894d9bd4d17931b9afcf230c0e7f4cb3d674
+  React-jsitooling: 03ead841daa12a93b18479f5e400ceab3732d36d
+  React-jsitracing: 4ae61c79e14360d1c6ab566031c62c490da78439
+  React-logger: bf149dea4343a9037b74bade36cced8b63f03f46
+  React-Mapbuffer: fec3e025f0ffba6b32cd2a1d7bbdee3e269aae90
+  React-microtasksnativemodule: ab33a818d339f5a1da308893c11b487be66121a8
+  React-mutationobservernativemodule: a42d1626651ccd7d0dc02a56e69d4ec77c248893
+  react-native-safe-area-context: fb5c8ee9f6dd62ef710611b3d370c501f42a4ac0
+  React-NativeModulesApple: deba264b03bd79c6bd61014fa30e40321b5e443a
+  React-networking: 35e6070b084f435429f85c5db40b4d5b38652fe9
   React-oscompat: 64a0c7ef5441855dc6e2a6afe8ba8f92aa05075e
-  React-perflogger: b2b0144e4ba8dd157c1e90f8ebb02d22edbd040d
-  React-performancecdpmetrics: 5a715ec33f2dea48a93a70db37a78b4f51f9fd5a
-  React-performancetimeline: c292077a6fbc7f423269b01aab0fb7cc48efe3c0
+  React-perflogger: ca04287f205086a1edb5c95882be7b6068458889
+  React-performancecdpmetrics: cf1d0a3178ccd59353cedcacbda421f40100a889
+  React-performancetimeline: c9771212e7a43032d6f8d5edfb58280d46a7ce1f
   React-RCTActionSheet: ab545c1e7b5f1ce4f8b40b6fa06afe2869095884
-  React-RCTAnimation: 1f9a58c7b74c25ea4ca6e6fbd05f37cc4919097a
-  React-RCTAppDelegate: 856f82c57b47c1795009af585cfb7b87fe2d3b5a
-  React-RCTBlob: 1cb18861a19be0b4d7e44bed9315e791413399f9
-  React-RCTFabric: 081853d9efb9b38fa868c1ff3d60e48106fe2a24
-  React-RCTFBReactNativeSpec: cbc760c7a889bfce20746ca0037b97c10ea58665
-  React-RCTImage: 0d94b22644ca87fcb778a8fa3ffbf990bc9028df
-  React-RCTLinking: 881a0c6772dd05a14ab0edfea05dadb698ec8090
-  React-RCTNetwork: feb412861e3fff3426eb0961c2acdd96bee8dce1
-  React-RCTRuntime: c61b848ffadc0209fe643406370d58021bd3585d
-  React-RCTSettings: b6e14b8764f807ebe9be2e7f0d72be83b359ac26
-  React-RCTText: 1ecd4f85ff609183ebec858cf94c0f27a9dec163
-  React-RCTVibration: 3611aa5cb59094632b3141d72c50cbb8ce3d5b08
+  React-RCTAnimation: 343147a9cd68c93d0ca280799fedfc7102d76ce4
+  React-RCTAppDelegate: 5054754e92aaa9f8bfabe0f1022b84e46f3dcb57
+  React-RCTBlob: 8c7ae3422ca4e72bc64b7a0142fd730efc5d4dfb
+  React-RCTFabric: be458db054b206c4d8e4f20f666e75d5f2c2d420
+  React-RCTFBReactNativeSpec: 06db2e8d0f352d9fa23321aed1dd2cde25a3e83c
+  React-RCTImage: 481457bca63e039eb997f7d16c7560472f49657e
+  React-RCTLinking: 76cbb871240cec2dc5e7aa26c60f59e0ebbcf5a2
+  React-RCTNetwork: e23a778225b7672e38545d3c5c24e1f4aad6d15f
+  React-RCTRuntime: 93c830b3ab3f7b494bbe7ae7289784f8b07b3947
+  React-RCTSettings: 96196b535bef147381f96cc60ce9bda85d8be848
+  React-RCTText: 749ebbd1a999fd84d80f37002ea3bf597fcea6df
+  React-RCTVibration: 5b41a7f274757c2928845981d970916ef9e4ca14
   React-rendererconsistency: 6708acd4bc39c1c5b00164370d0010d93b324c1f
-  React-renderercss: d4a70898381431dcc07d6deba94a7eaef0cc9058
-  React-rendererdebug: ad92235a960983f69183e2e59e2bce21e72c80a0
-  React-RuntimeApple: 53a5b8fe60b044ec6fd4d254d66b7da69314a295
-  React-RuntimeCore: 97e125471c0b8313db2bbeb1e9dc001a5503e979
-  React-runtimeexecutor: 0ff42dcf1cc4bc7a89d29532a16a7d2d3849fb2f
-  React-RuntimeHermes: da5a1b7e39f3db1a7b3303d75d4c5bb6cd7c0d49
-  React-runtimescheduler: 0e24c80f0c8b6e822a33e4ad89e0ab555704eedb
-  React-timing: f23e82ad46673716e34a786048414ab80f237594
-  React-utils: 2851415c698da4b18331f9a445825d260fffa32c
-  React-webperformancenativemodule: 9f29ed34f6f6c01dac688b95fd2dfcbccf3aed7a
-  ReactAppDependencyProvider: a54c0c9b976766e1b6d5e2bb4d1ad0d15913e9e1
-  ReactCodegen: 9af5798e943781fd2318dab7b60f25337388047c
-  ReactCommon: 3ec2a55999d296af90c24beb66c8a77dc660d3ef
+  React-renderercss: 80eb778756fed511d6128fc005188ac9008b0baf
+  React-rendererdebug: b46f338fb9d3f0bea6cf0621016c6c5a7a18e72e
+  React-RuntimeApple: c494b2089fad4a0c553cf63c2bb265f7eca2285d
+  React-RuntimeCore: b0bb151c3e2b26c6309d45d05c54aa65a6e0c094
+  React-runtimeexecutor: 00b18635b6216a1708f6eb35dbadfd993ec91c7b
+  React-RuntimeHermes: bb44c4c574ce1b9507cad2e6be015344d18b94a9
+  React-runtimescheduler: e1631e57209cb94b3efc29002b6a049cac3f6599
+  React-timing: 356b88317ca60d373b0d94b6e7a71b0a572899f5
+  React-utils: ccc01da318979af773259c4f6cdb1876f6f86f1a
+  React-webperformancenativemodule: f8b97c2cb6cfa94e92a503c09ad6d491c50a1390
+  ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
+  ReactCodegen: c8f81e6c6f762dcf442a6203a1fb58f7dafc8014
+  ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
   ReactNativeDependencies: 50dcda1d46c2178957063022dcbd086567410265
-  RNPermissions: 641fa7221cc481bf7a913768f8f4969ef0a4bfa0
-  RNReanimated: 59bf185693b7294a0c515e19a6d1be54def61363
-  RNSVG: a37350c7bc37452fd2b209efa0806f1de0f847ae
-  RNWorklets: 32b9ca9e0588b838ce3202a9ea3971f553c9011c
-  StepCounter: f17e2184888b06b1d1f81d3645ef1561c4ed06bc
+  RNPermissions: 17dfc8720f9fee1d16268bbbecd5085fc15078f4
+  RNReanimated: f735b1747a7a93bda7ca102c6d37a3cf54b6d5e8
+  RNSVG: 0e52210d4d43165e7e2cf9c890a9848b27e513ac
+  RNWorklets: 4931990f73bc8f347586918b2e13f11dfadf3b75
+  StepCounter: 4f5ad65f5c99f0168c2e483fc6c81b180893ff27
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 
 PODFILE CHECKSUM: cc844e779d2f3a18b09e701a6bedf73e1a9a94c6
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2340,7 +2340,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 0770e14b75cb4323e9d55f5f4ab09838f050ed8b
+  hermes-engine: 595b6a8fd49c314d5ec53e0750f5bd359357dc0c
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
@@ -2349,7 +2349,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: f90d375d3bab515ad00df30605ce1bf02e6db12f
-  React-Core-prebuilt: 3b7b7bce7a1ed104cca52c8e18fb19c2a588045e
+  React-Core-prebuilt: 929d85171bd5ae75faa8685b047c8ae79596aa9d
   React-CoreModules: da4f80202ef954bdfb926ca4c9ac5f685900aa5c
   React-cxxreact: 1d1d2a28a5f10e4e2e7cf2bfd54dc9c92c68c672
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -2412,7 +2412,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: a54c0c9b976766e1b6d5e2bb4d1ad0d15913e9e1
   ReactCodegen: 9af5798e943781fd2318dab7b60f25337388047c
   ReactCommon: 3ec2a55999d296af90c24beb66c8a77dc660d3ef
-  ReactNativeDependencies: fb7b00723e4221c06926ca7e8984c87aed5afee0
+  ReactNativeDependencies: 50dcda1d46c2178957063022dcbd086567410265
   RNPermissions: 641fa7221cc481bf7a913768f8f4969ef0a4bfa0
   RNReanimated: 59bf185693b7294a0c515e19a6d1be54def61363
   RNSVG: a37350c7bc37452fd2b209efa0806f1de0f847ae

--- a/example/osv-scanner.toml
+++ b/example/osv-scanner.toml
@@ -1,26 +1,3 @@
 # OSV-Scanner ignore list.
 # Each entry is a vulnerability that cannot currently be remediated by an
 # upgrade in this repository. Include a date so entries do not go stale.
-
-# concurrent-ruby (example/Gemfile.lock) is pinned to `< 1.3.4` in
-# `example/Gemfile` to avoid known CocoaPods / activesupport build failures.
-# The advisories below are all fixed in concurrent-ruby 1.3.7, but that pin
-# blocks the upgrade. This gem is part of the example app's iOS build tooling
-# (Ruby/CocoaPods) and is NOT shipped in the published npm package. Re-evaluate
-# by bumping the `< 1.3.4` pin to `>= 1.3.7` and running `bundle update` in the
-# iOS environment (the Gemfile already declares `logger`, the usual blocker).
-# Recorded 2026-07-12.
-[[IgnoredVulns]]
-id = "GHSA-h8w8-99g7-qmvj"
-ignoreUntil = 2026-10-01
-reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."
-
-[[IgnoredVulns]]
-id = "GHSA-6wx8-w4f5-wwcr"
-ignoreUntil = 2026-10-01
-reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."
-
-[[IgnoredVulns]]
-id = "GHSA-wv3x-4vxv-whpp"
-ignoreUntil = 2026-10-01
-reason = "concurrent-ruby fixed in 1.3.7, blocked by intentional `< 1.3.4` pin in example/Gemfile (CocoaPods compat); example-only Ruby tooling, not in the published package. Re-evaluate 2026-10 or when the pin can be lifted."


### PR DESCRIPTION
## 🔍 Summary

**What:** Removes the `gem 'concurrent-ruby', '< 1.3.4'` pin from `example/Gemfile`, moving the lockfile from `1.3.3` to `1.3.7`, drops the now-obsolete osv-scanner suppressions that the pin justified, corrects the stale Ruby floor that lifting the pin turned into a trap, and realigns `Podfile.lock` with the CocoaPods version the Gemfile actually declares.

**Why:** That pin was holding back three open Dependabot alerts, all patched in `1.3.7`:

| Severity | Advisory | Issue |
| --- | --- | --- |
| HIGH | `GHSA-h8w8-99g7-qmvj` | `AtomicReference#update` livelocks when the stored value is `Float::NAN` |
| LOW | `GHSA-wv3x-4vxv-whpp` | `ReentrantReadWriteLock` read-count overflow lets a write lock be acquired without exclusivity |
| LOW | `GHSA-6wx8-w4f5-wwcr` | `ReadWriteLock` allows releasing another thread's write lock, corrupting the read counter |

**On the pin's origin.** It entered in `323e1fa` (2026-02-20) as a drive-by change inside an unrelated iOS accuracy commit, with no explanation in the commit message, and survived two later `example/Gemfile` edits — including `14a6bba`, a security-only pass.

The one place it was ever explained is `example/osv-scanner.toml`, added months later in `7efb9cc` (2026-07-12), which attributed the pin to "known CocoaPods / activesupport build failures" and prescribed the re-evaluation this PR performs. That claim did not survive testing: CocoaPods `1.15.2` (via `bundle exec`) and `1.16.2` (via `yarn example ios`) both install cleanly against `concurrent-ruby 1.3.7`. So the pin is removed rather than kept and re-documented — and because the suppressions rested on that same premise, they go with it.

## 🛠️ Changes

- `2c55844` — removed the `concurrent-ruby < 1.3.4` constraint from `example/Gemfile` and regenerated `example/Gemfile.lock` (`1.3.3` → `1.3.7`); `BUNDLED WITH 4.0.6` and the `CHECKSUMS` section are preserved
- `977a763` — refreshed three prebuilt-pod spec checksums in `example/ios/Podfile.lock` (`hermes-engine`, `React-Core-prebuilt`, `ReactNativeDependencies`). These generate their podspec at install time, so the values track the local install rather than any dependency change — no pod versions moved.
- `6770241` — removed all three `IgnoredVulns` entries from `example/osv-scanner.toml`. They suppressed the same three advisories through 2026-10-01 on the grounds that the pin blocked remediation; leaving them would have let an accidental downgrade back to a vulnerable `concurrent-ruby` pass the repository's security check. The file header is kept so the "record a date" convention survives.
- `b12dcd1` — raised `ruby ">= 2.6.10"` to `">= 3.1.0"` in `example/Gemfile`. The old floor never described reality: the lockfile pins activesupport `7.2.3.1`, whose `required_ruby_version` is `>= 3.1.0`. Lifting the concurrent-ruby pin made that staleness load-bearing — a fresh resolve on Ruby 2.6 would fall back to activesupport 6.1.x, which expects `Logger` to have been required transitively, something concurrent-ruby stopped doing in 1.3.5. `Gemfile.lock` is unchanged by this, confirming it constrains nothing that was actually resolvable.
- `a824508` — regenerated `example/ios/Podfile.lock` with `bundle exec pod install`, moving it from `COCOAPODS: 1.16.2` to `1.15.2`. The 1.16.2 lockfile was produced outside the declared toolchain: the Gemfile caps CocoaPods at 1.15.x (1.16.2 needs `xcodeproj >= 1.27.0`, and the Gemfile pins `xcodeproj < 1.26.0`), so the committed artifact violated the repo's own constraints. `yarn example ios` and the `postclean` script invoke a bare `pod`, bypassing bundler — that is where the drift comes from. No pins changed, nothing upgraded.

## 🔗 Related Issue

Closes the three open `concurrent-ruby` Dependabot alerts (no tracking issue filed).

## ✅ Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (backwards-incompatible)
- [ ] Documentation update
- [ ] Chore / Refactoring

## 📋 Checklist

- [x] My code follows the repository's style guidelines
- [ ] I have added tests covering my changes — n/a, no source change
- [x] I have run `trunk check` — `--filter=osv-scanner` against `example/Gemfile.lock`, no issues. `yarn jest` not run: this PR touches only Ruby/CocoaPods/TOML files and no JS/TS, so it does not exercise the change.
- [ ] I have updated the README or relevant documentation — n/a
- [x] I have provided version and environment details if applicable

## 🚀 How to Test

Verified locally on Ruby 3.2.0 / Bundler 4.0.6 / macOS arm64:

```sh
cd example
bundle exec pod --version                        # 1.15.2 — loads cleanly against concurrent-ruby 1.3.7
grep 'concurrent-ruby (' Gemfile.lock            # concurrent-ruby (1.3.7)
bundle exec pod install --project-directory=ios  # exit 0

cd .. && trunk check --filter=osv-scanner example/Gemfile.lock   # no issues, zero suppressions
```

The osv-scanner run matters most: with the ignore list emptied, the lockfile is clean on its own, so the advisories are resolved by the upgrade rather than hidden.

On CI, `native-ios.yml` was dispatched on this branch several times. The authoritative run is [29668327433](https://github.com/AndrewDongminYoo/react-native-step-counter/actions/runs/29668327433) on `a824508`: it missed the CocoaPods cache, so `Install cocoapods` executed `bundle install` → `bundle exec pod repo update` → `bundle exec pod install` against `concurrent-ruby 1.3.7` on the new `>= 3.1.0` Ruby floor, and `yarn example build:ios` then completed. That single run exercises every change in this PR.

> [!IMPORTANT]
> A follow-up dispatch on the same commit failed, and it is worth being precise about why, because it is **not** caused by this PR. When the CocoaPods cache hits exactly, `Install cocoapods` is skipped by its `if: steps.cocoapods-cache.outputs.cache-hit != 'true'` guard. But `pod install` also runs codegen into `example/ios/build/generated/ios/`, which is gitignored and not covered by the workflow's `**/ios/Pods` cache path — so a cache hit restores `Pods/` without the generated podspecs it references, and the build dies on `No podspec found for ReactAppDependencyProvider`. This breaks every cache-hit run on any branch, independent of dependencies. `a824508` did fix the separate `COCOAPODS 1.16.2 > 1.15.2` error that previously masked it. The suggested repair — dropping the `if:` guard so `pod install` always runs, keeping the cache purely for download speed — belongs with the workflow-trigger rework, not here.

> [!NOTE]
> GitHub Actions was non-functional repo-wide until 2026-07-19 — the repository was set to `allowed_actions: local_only`, so every workflow using a third-party action (`actions/checkout`, `actions/setup-node`, `actions/cache`, `maxim-lobanov/setup-xcode`) failed at startup in 0s. Every `ci.yml` run on record, including on `main` and through the `v0.5.0` release, is `startup_failure`. The setting has since been narrowed to `selected` with `github_owned_allowed` plus `maxim-lobanov/setup-xcode@*`, and workflows now start. Noted because it means CI history before this date proves nothing.

## 📸 Screenshots (if applicable)

n/a — no UI or visual output.
